### PR TITLE
Refine mmWave channel generation allocation

### DIFF
--- a/Dataset/28GHz/full_generator_MM.m
+++ b/Dataset/28GHz/full_generator_MM.m
@@ -7,31 +7,41 @@ addpath('DeepMIMO_functions')
 row_num = 2751;
 % UE number in each row
 UE_row_num = 181;
-% mmWave BS number
-BS_num = 12;
-% candidate mmWave channel
-MM_channel = zeros(BS_num, UE_row_num, 64);
 
 % mmWave channel parameters
 params = read_params('parameters_mm.m');
 
+% determine the number of BS and antennas from the loaded parameters
+BS_num  = numel(params.active_BS);
+ant_num = params.num_ant_x * params.num_ant_y * params.num_ant_z;
+
 % for each row
 for i = 1 : row_num
+    % preallocate candidate mmWave channel for this row
+    MM_channel = zeros(BS_num, UE_row_num, ant_num);
+
     % select active users (this row)
     params.active_user_first = i;
-    params.active_user_last = i;
-    print_info = ['mmWave dataset ' num2str(i) 'th row generation started']
+    params.active_user_last  = i;
+    print_info = ['mmWave dataset ' num2str(i) 'th row generation started'];
+
     % generate corresponding channels and parameters
     [dataset_MM, params_MM] = DeepMIMO_generator(params);
+
     % save channels into matrices
-    for j = 1 : BS_num
+    for j = 1 : numel(dataset_MM)
         for k = 1 : UE_row_num
-            MM_channel(j, k, :) = squeeze(sum(dataset_MM{j}.user{k}.channel, 3));
+            ch = squeeze(sum(dataset_MM{j}.user{k}.channel, 3));
+            if params.num_ant_MS_z > 1
+                ch = sum(ch, 1);
+            end
+            MM_channel(j, k, :) = ch;
         end
     end
+
     % save channels into files
     fprintf('\n Saving the DeepMIMO Dataset ...')
     sfile_DeepMIMO = ['./MM_dataset/MM_DeepMIMO_dataset_' num2str(i) '_row.mat'];
-    save(sfile_DeepMIMO,'MM_channel', '-v7.3');
+    save(sfile_DeepMIMO, 'MM_channel', '-v7.3');
 end
 fprintf('\n DeepMIMO Dataset Generation completed \n')


### PR DESCRIPTION
## Summary
- derive BS and antenna counts from parameters and preallocate accordingly
- iterate over returned base station datasets and aggregate UE antenna dimensions when needed

## Testing
- `octave --version` (fails: command not found)
- `apt-get install -y octave` (fails: ca-certificates-java post-installation script error)


------
https://chatgpt.com/codex/tasks/task_e_68bbeadfe5cc832287cd2335b1dbf7ae