### PR TITLE
Make beam count configurable in ODE model

### DIFF
--- a/Prediction_scheme/ODE/tests/test_model_forward.py
+++ b/Prediction_scheme/ODE/tests/test_model_forward.py
@@ -1,0 +1,23 @@
+import torch
+from Prediction_scheme.ODE.model_ODE import Model_3D
+
+
+def _run_forward(beams, out_feature=None):
+    model = Model_3D(out_feature=out_feature)
+    x = torch.randn(2, 2, 101, beams)
+    # use smaller timespans/pre_points for faster unit tests
+    y = model(x, timespans=2, pre_points=3)
+    assert y.shape == (3, 2, 2, beams)
+    assert model.out_feature == beams
+
+
+def test_forward_64_beams():
+    _run_forward(64, out_feature=64)
+
+
+def test_forward_512_beams():
+    _run_forward(512, out_feature=512)
+
+
+def test_forward_infer_from_input():
+    _run_forward(64, out_feature=None)

--- a/Prediction_scheme/ODE/train_ODE.py
+++ b/Prediction_scheme/ODE/train_ODE.py
@@ -9,6 +9,7 @@ from dataloader_3D import Dataloader_3D
 from model_ODE import Model_3D
 import sys
 import time
+import argparse
 
 # model_evaluation
 def eval(model, loader, total, m):
@@ -140,7 +141,7 @@ def eval(model, loader, total, m):
 
 # main function for model training and evaluation
 # output: accuracy, losses and normalized beamforming gain
-def main():
+def main(out_feature=64):
     # first loop for different velocities
     for velocity in [5, 10, 15, 20, 25, 30]:
         # save corresponding information
@@ -183,7 +184,7 @@ def main():
             # learning rate
             lr = 0.00003
             # model initialization
-            model = Model_3D()
+            model = Model_3D(out_feature=out_feature)
             model.to(device)
             # Adam optimizer
             optimizer = torch.optim.Adam(model.parameters(), lr, betas=(0.9, 0.999))
@@ -277,4 +278,8 @@ def main():
                                        'time_eval': time_eval})
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description='Train ODE model')
+    parser.add_argument('--beams', type=int, default=64,
+                        help='number of beams to predict (out_feature)')
+    args = parser.parse_args()
+    main(out_feature=args.beams)


### PR DESCRIPTION
## Summary
- Allow `Model_3D` to accept any number of beams by making `out_feature` optional and lazily initialising the output layer
- Add command‑line flag to `train_ODE.py` to configure beam count during training
- Add unit tests ensuring the model forward pass works for 64 and 512 beams and when inferring beam count from input

## Testing
- `pytest Prediction_scheme/ODE/tests/test_model_forward.py -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bbee8627c083229c1ddf2019081636